### PR TITLE
transip-api dependency breakage

### DIFF
--- a/_CI/scripts/test
+++ b/_CI/scripts/test
@@ -7,12 +7,14 @@ pip install -r requirements/testing.txt
 
 rm -rf test-output
 mkdir -p test-output/coverage
-# start: what?
 touch test-output/coverage/index.html
-# end: what?
 tox
 exit_code=$?
-open test-output/coverage/index.html 2> /dev/null|| xdg-open test-output/coverage/index.html &
-sleep 1
-open test-output/nosetests.html 2> /dev/null|| xdg-open test-output/nosetests.html &
-exit $exit_code
+
+if [[ -z "${CI}" ]]; then
+    # if NOT in a CI env then do the following
+    open test-output/coverage/index.html 2> /dev/null|| xdg-open test-output/coverage/index.html &
+    sleep 1
+    open test-output/nosetests.html 2> /dev/null|| xdg-open test-output/nosetests.html &
+    exit $exit_code
+fi

--- a/_CI/scripts/test
+++ b/_CI/scripts/test
@@ -6,7 +6,10 @@ cd $(dirname $0)/../..
 pip install -r requirements/testing.txt
 
 rm -rf test-output
-mkdir -p test-output
+mkdir -p test-output/coverage
+# start: what?
+touch test-output/coverage/index.html
+# end: what?
 tox
 exit_code=$?
 open test-output/coverage/index.html 2> /dev/null|| xdg-open test-output/coverage/index.html &

--- a/certbot_dns_transip/dns_transip.py
+++ b/certbot_dns_transip/dns_transip.py
@@ -7,7 +7,7 @@ import logging
 import os
 from tempfile import mktemp
 
-from transip.service.dns import DnsEntry
+from transip.service.objects import DnsEntry
 from transip.service.domain import DomainService
 import suds
 import zope.interface

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 acme>=0.16.0
 certbot>=0.16.0
-transip>=0.3.0
+transip>=0.4.0
 setuptools>=1.0
 six>=1.10.0
 zope.interface>=4.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 acme>=0.16.0
 certbot>=0.16.0
-transip>=0.4.0
+transip==0.4.0
 setuptools>=1.0
 six>=1.10.0
 zope.interface>=4.4.2

--- a/tests/test_certbot_dns_transip.py
+++ b/tests/test_certbot_dns_transip.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from transip.service.dns import DnsEntry
+from transip.service.objects import DnsEntry
 from certbot.plugins import dns_test_common
 from certbot.plugins.dns_test_common import DOMAIN
 from certbot.tests import util as test_util


### PR DESCRIPTION
[transip-api](https://github.com/benkonrath/transip-api)  has updated to `0.4.0` the required semver `>=0.3.0` installs this version (0.4.0). This new minor version `0.4.0` introduces a breaking change where interface `transip.service.dns` is now `transip.service.objects`.

See also https://github.com/benkonrath/transip-api/issues/27

This PR fixes the dependency problem ;-) Though I can't tell if more is broken. 
Possibly the fix should be to explicitly change the dependency to` =0.3.0` to reduce any other possible breakages... 
