### PR TITLE
Add Docker command example to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,4 +7,17 @@ Certbot plugin to authenticate using dns TXT records via Transip API
 
 * Documentation: https://readthedocs.org/projects/certbot-dns-transip/
 
-* Running with docker: `docker run -ti -v $PWD/transip.ini:/transip.ini -v $PWD/transip-rsa.key:/transip-rsa.key hsmade/certbot-transip certonly -d <host.domain.tld> -a certbot-dns-transip:dns-transip --certbot-dns-transip:dns-transip-credentials transip.ini --certbot-dns-transip:dns-transip-propagation-seconds 240`
+You can also run this directly from Docker, and get the certificates and keys written to disk for further processing.
+
+For example the following command can be used. This assumes the `transip.ini` file and the keyfile are present in `/tmp/letsencrypt`. ::
+
+    docker run -ti -v `/tmp/letsencrypt`:/etc/letsencrypt \
+        hsmade/certbot-transip \
+        certbot certonly -n \
+        -d 'your.domain.com' \
+        -a certbot-dns-transip:dns-transip \
+        --certbot-dns-transip:dns-transip-credentials /etc/letsencrypt/transip.ini \
+        --certbot-dns-transip:dns-transip-propagation-seconds 240 \
+        -m your@domain.com \
+        --agree-tos \
+        --eff-email


### PR DESCRIPTION
This adds an example command on how to "headlessly" request new certificates and get them as a file to the readme.

I also noticed the current container on Docker Hub is a bit outdated, perhaps it is an idea to add an _Automatic Build_ for it? https://docs.docker.com/docker-hub/builds/