### PR TITLE
Add Python 3.12+ compatibility (remove distutils dependency)

### DIFF
--- a/certbot_dns_transip/dns_transip.py
+++ b/certbot_dns_transip/dns_transip.py
@@ -5,7 +5,6 @@
 import logging
 import os
 from tempfile import mktemp
-from distutils.util import strtobool
 
 import transip
 from certbot import errors
@@ -22,6 +21,15 @@ TRANSIP_EXCEPTIONS = (
     transip.exceptions.TransIPIOError,
     transip.exceptions.TransIPParsingError
 )
+
+
+def _strtobool(value):
+    value = value.lower()
+    if value in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    if value in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    raise ValueError("invalid truth value {0!r}".format(value))
 
 
 class Authenticator(dns_common.DNSAuthenticator):
@@ -79,7 +87,7 @@ class Authenticator(dns_common.DNSAuthenticator):
         username = self.credentials.conf('username')
         global_key = False
         try:
-            global_key = bool(strtobool(self.credentials.conf('global_key')))
+            global_key = bool(_strtobool(self.credentials.conf('global_key')))
         except ValueError:
             raise ValueError("dns_transip_global_key should have either 'yes' or 'no' as value")
         except AttributeError:  # global_key was not present in the config, use default


### PR DESCRIPTION
This pull request updates the library to ensure compatibility with Python 3.12 and newer.

### Background

`distutils` has been deprecated and removed in Python 3.12. The project previously relied on:

```python
from distutils.util import strtobool
```

This import fails under Python 3.12+, breaking runtime compatibility.

### Changes

1. **Removed `distutils` dependency**

   * Deleted: `from distutils.util import strtobool`

2. **Introduced local `_strtobool` implementation**

   * Added an internal helper function replicating the behavior of `distutils.util.strtobool`.
   * Preserves the same accepted truthy/falsy values:

     * Truthy: `y`, `yes`, `t`, `true`, `on`, `1`
     * Falsy: `n`, `no`, `f`, `false`, `off`, `0`
   * Raises `ValueError` for invalid inputs (consistent with original behavior).

3. **Updated usage**

   * Replaced calls to `strtobool(...)` with `_strtobool(...)`.
   * Existing error handling remains unchanged.

### Impact

* Restores compatibility with Python 3.12+.
* No behavioral changes in boolean parsing.
* No new external dependencies introduced.
* Fully backward compatible with earlier supported Python versions.

### Rationale

Implementing a minimal internal version of `strtobool` avoids introducing a new dependency (e.g., `setuptools`) solely to replace removed `distutils` functionality. The change is isolated, deterministic, and low-risk.